### PR TITLE
Make history filename customizable

### DIFF
--- a/history/history.plugin.zsh
+++ b/history/history.plugin.zsh
@@ -18,9 +18,9 @@ setopt HIST_BEEP              # Beep when accessing non-existent history.
 # Variables
 #
 
-HISTFILE="${ZDOTDIR:-$HOME}/.zhistory" # The path to the history file.
-HISTSIZE=10000                         # The maximum number of events to save in the internal history.
-SAVEHIST=10000                         # The maximum number of events to save in the history file.
+HISTFILE="${ZDOTDIR:-$HOME}/${ZHISTFILE:-.zhistory}" # The path to the history file.
+HISTSIZE=10000                                       # The maximum number of events to save in the internal history.
+SAVEHIST=10000                                       # The maximum number of events to save in the history file.
 
 #
 # Aliases


### PR DESCRIPTION
Enable the user to customize the filename of HISTFILE.
For example; I would prefer continue using my `.zsh_history` instead of switching to `.zhistory`, and thus loosing all my history.