### PR TITLE
Add XDG basedir support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,29 @@ bindkey -e
 - prompt - Load and initialize the build-in zsh prompt system
 - utility - Common shell utilities, aimed at making cross platform work less painful
 
+## Configuration
+
+[XDG base directory locations][xdg-basedirs] can be used for `$HISTFILE` in
+the history plugin, and `zcompdump` and `zcompcache` in the completions
+plugin. This is helpful if you want to move these files out of your `$HOME`
+or `$ZDOTDIR` directories.
+
+To use XDG base directory locations, set the following zstyle:
+
+```zsh
+zstyle ':zsh-utils:*:*' use-xdg-basedirs 'yes'
+```
+
+Or, you can set it individually for each plugin:
+
+```zsh
+zstyle ':zsh-utils:plugins:history' use-xdg-basedirs 'no'
+zstyle ':zsh-utils:plugins:completion' use-xdg-basedirs 'yes'
+```
+
 ## Plugin Details
 
 For more specific information about the plugins, check out [PLUGINS.md](./PLUGINS.md).
+
+
+[xdg-basedirs]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

--- a/completion/completion.plugin.zsh
+++ b/completion/completion.plugin.zsh
@@ -6,6 +6,16 @@ if [[ "$TERM" == 'dumb' ]]; then
   return 1
 fi
 
+# Check whether to use XDG basedir locations or $ZDOTDIR.
+if zstyle -t ':zsh-utils:plugins:completion' use-xdg-basedirs; then
+  [[ -d ${XDG_CACHE_HOME:-$HOME/.cache}/zsh ]] || mkdir -p ${XDG_CACHE_HOME:-$HOME/.cache}/zsh
+  _zcompdump="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump"
+  _zcompcache="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompcache"
+else
+  _zcompdump="${ZDOTDIR:-$HOME}/.zcompdump"
+  _zcompcache="${ZDOTDIR:-$HOME}/.zcompcache"
+fi
+
 #
 # Options
 #
@@ -25,7 +35,7 @@ unsetopt FLOW_CONTROL      # Disable start/stop characters in shell editor.
 
 # Use caching to make completion for commands such as dpkg and apt usable.
 zstyle ':completion::complete:*' use-cache on
-zstyle ':completion::complete:*' cache-path "${ZDOTDIR:-$HOME}/.zcompcache"
+zstyle ':completion::complete:*' cache-path "$_zcompcache"
 
 #
 # Init
@@ -35,10 +45,10 @@ zstyle ':completion::complete:*' cache-path "${ZDOTDIR:-$HOME}/.zcompcache"
 # cache time of 20 hours, so it should almost always regenerate the first time a
 # shell is opened each day.
 autoload -Uz compinit
-_comp_files=(${ZDOTDIR:-$HOME}/.zcompdump(Nmh-20))
+_comp_files=($_zcompdump(Nmh-20))
 if (( $#_comp_files )); then
-  compinit -i -C
+  compinit -i -C -d "$_zcompdump"
 else
-  compinit -i
+  compinit -i -d "$_zcompdump"
 fi
-unset _comp_files
+unset _comp_files _zcompdump _zcompcache

--- a/history/history.plugin.zsh
+++ b/history/history.plugin.zsh
@@ -18,9 +18,15 @@ setopt HIST_BEEP              # Beep when accessing non-existent history.
 # Variables
 #
 
-HISTFILE="${ZDOTDIR:-$HOME}/${ZHISTFILE:-.zsh_history}" # The path to the history file.
-HISTSIZE=10000                                          # The maximum number of events to save in the internal history.
-SAVEHIST=10000                                          # The maximum number of events to save in the history file.
+# Set the path to the history file.
+if zstyle -t ':zsh-utils:plugins:history' use-xdg-basedirs; then
+  HISTFILE="${XDG_DATA_HOME:-$HOME/.local/share}/zsh/${ZHISTFILE:-history}"
+  [[ -d "${HISTFILE:h}" ]] || mkdir -p "${HISTFILE:h}"
+else
+  HISTFILE="${ZDOTDIR:-$HOME}/${ZHISTFILE:-.zsh_history}"
+fi
+HISTSIZE=10000  # The maximum number of events to save in the internal history.
+SAVEHIST=10000  # The maximum number of events to save in the history file.
 
 #
 # Aliases


### PR DESCRIPTION
Add support for storing $HISTFILE and zcompdump/zcompcache in the XDG base directory locations (`$XDG_DATA_HOME` & `$XDG_CACHE_HOME`).