### PR TITLE
Use built-in zsh `run-help`

### DIFF
--- a/utility/utility.plugin.zsh
+++ b/utility/utility.plugin.zsh
@@ -62,6 +62,10 @@ fi
 alias pbc='pbcopy'
 alias pbp='pbpaste'
 
+# Load more specific 'run-help' function from $fpath.
+(( $+aliases[run-help] )) && unalias run-help && autoload -Uz run-help
+alias help=run-help
+
 #
 # Cleanup
 #


### PR DESCRIPTION
The Zsh `run-help` is really useful.

```zsh
$ # no help
$ man typeset
No manual entry for typeset
$ # jackpot!
$ run-help typeset
typeset [ {+|-}AHUaghlmrtux ] [ {+|-}EFLRZip [ n ] ]
...

$ # nada
$ man zstyle
$ # actual zsh help!
$ run-help zstyle
zstyle See the section 'The zsh/zutil Module' in zshmodules(1).
$ run-help zshmodules
...useful information...
```

This PR unaliases `run-help=man` and `autoload`s the zsh built-in `run-help`. Then it aliases `help=run-help`.