### PR TITLE
Cache expensive dircolors eval

### DIFF
--- a/utility/utility.plugin.zsh
+++ b/utility/utility.plugin.zsh
@@ -11,7 +11,15 @@ function -coreutils-alias-setup {
   # installed alongside BSD Coreutils
   local prefix=$1
 
-  eval "$(${prefix}dircolors --sh)"
+  # Cache results of running dircolors for 20 hours, so it should almost
+  # always regenerate the first time a shell is opened each day.
+  local dircolors_cache=${XDG_CACHE_HOME:-$HOME/.cache}/zsh-utils/${prefix}dircolors.zsh
+  local cache_files=($dircolors_cache(Nmh-20))
+  if ! (( $#cache_files )); then
+    mkdir -p "${dircolors_cache:h}"
+    ${prefix}dircolors --sh >| $dircolors_cache
+  fi
+  source "${dircolors_cache}"
 
   alias ${prefix}ls="${aliases[${prefix}ls]:-${prefix}ls} --group-directories-first --color=auto"
 }


### PR DESCRIPTION
The call to `eval "$(${prefix}dircolors --sh)"` is not real efficient. On my M1 Mac, when profiling a naked Zsh setup with zsh-utils, I get these results:

```zsh
~/P/m/zsh-utils % zprofrc
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    1          16.55    16.55   64.11%     16.55    16.55   64.11%  compinit
 2)    1           4.60     4.60   17.84%      4.60     4.60   17.84%  -coreutils-alias-setup
 3)    2           2.73     1.36   10.56%      2.73     1.36   10.56%  promptinit
 4)    8           0.85     0.11    3.28%      0.82     0.10    3.16%  add-zle-hook-widget
 5)    8           0.54     0.07    2.11%      0.54     0.07    2.11%  add-zsh-hook
 6)    2           0.36     0.18    1.39%      0.32     0.16    1.23%  prompt_belak_setup
 7)    1           1.86     1.86    7.21%      0.15     0.15    0.59%  set_prompt
 8)    1           1.93     1.93    7.49%      0.07     0.07    0.28%  prompt
 9)    1           0.03     0.03    0.12%      0.03     0.03    0.12%  (anon) [/opt/homebrew/Cellar/zsh/5.9/share/zsh/functions/add-zle-hook-widget:28]
```

By caching the call to (g)dircolors similar to compinit, we get the following results:

```zsh
~/P/m/zsh-utils % zprofrc
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    1          15.24    15.24   79.21%     15.24    15.24   79.21%  compinit
 2)    2           2.45     1.23   12.74%      2.45     1.23   12.74%  promptinit
 3)    8           0.67     0.08    3.47%      0.64     0.08    3.33%  add-zle-hook-widget
 4)    8           0.37     0.05    1.94%      0.37     0.05    1.94%  add-zsh-hook
 5)    2           0.23     0.12    1.21%      0.19     0.10    1.00%  prompt_belak_setup
 6)    1           1.38     1.38    7.16%      0.15     0.15    0.76%  set_prompt
 7)    1           0.11     0.11    0.57%      0.11     0.11    0.57%  -coreutils-alias-setup
 8)    1           1.44     1.44    7.48%      0.06     0.06    0.32%  prompt
 9)    1           0.03     0.03    0.14%      0.03     0.03    0.14%  (anon) [/opt/homebrew/Cellar/zsh/5.9/share/zsh/functions/add-zle-hook-widget:28]
```
