### PR TITLE
Fix zsh cache dir location

### DIFF
--- a/completion/completion.plugin.zsh
+++ b/completion/completion.plugin.zsh
@@ -11,8 +11,8 @@ if zstyle -T ':zsh-utils:plugins:completion' use-xdg-basedirs; then
   _cache_dir=${XDG_CACHE_HOME:-$HOME/.cache}/zsh
   [[ -d "$_cache_dir" ]] || mkdir -p "$_cache_dir"
 
-  _zcompdump="$_cache_dir/zsh/compdump"
-  _zcompcache="$_cache_dir/zsh/compcache"
+  _zcompdump="$_cache_dir/compdump"
+  _zcompcache="$_cache_dir/compcache"
 else
   _zcompdump="${ZDOTDIR:-$HOME}/.zcompdump"
   _zcompcache="${ZDOTDIR:-$HOME}/.zcompcache"


### PR DESCRIPTION
The cache directory already was pointed to a Zsh subdirectory with this line:

`_cache_dir=${XDG_CACHE_HOME:-$HOME/.cache}/zsh`

I missed it and mistakenly added another zsh directory with this line:

`_zcompdump="$_cache_dir/zsh/compdump"`

This PR removes the double zsh directory.

So effectively, `~/.cache/zsh/zsh/compdump` now goes correctly to `~/.cache/zsh/compdump`. This also fixes a subtle bug where `mkdir -p` wouldn't have created the right path for the compdump file.