### PR TITLE
completion: keep zcompdump younger than cache

### DIFF
--- a/completion/completion.plugin.zsh
+++ b/completion/completion.plugin.zsh
@@ -58,6 +58,8 @@ if (( $#_comp_files )); then
   compinit -i -C -d "$_zcompdump"
 else
   compinit -i -d "$_zcompdump"
+  # Keep $_zcompdump younger than cache time even if it isn't regenerated.
+  touch "$_zcompdump"
 fi
 
 #


### PR DESCRIPTION
I noticed that sometimes the zcompdump file doesn't change, and thus its modified date doesn't change, meaning that it gets caught in a pattern of always using the slower route to regenerate with no benefit.

Prezto suffered the same issue:
* https://github.com/sorin-ionescu/prezto/pull/1881
* https://github.com/sorin-ionescu/prezto/blob/e3a9583f3370e11a0da1414d3f335eac40c1e922/modules/completion/init.zsh#L53-L68

Others have also noticed this issue and discussed it here:
* https://gist.github.com/ctechols/ca1035271ad134841284?permalink_comment_id=3038548#gistcomment-3038548

This PR simply touches the zcompdump file when it takes the long route to rebuild completions to ensure that it stays younger than the cache limit.