### PR TITLE
replaced option -G with --color=auto for ls

### DIFF
--- a/utility/utility.plugin.zsh
+++ b/utility/utility.plugin.zsh
@@ -40,7 +40,7 @@ fi
 if (( $+commands[dircolors] )); then
   -coreutils-alias-setup
 else
-  alias ls="${aliases[ls]:-ls} -G"
+  alias ls="${aliases[ls]:-ls} --color=auto"
 fi
 
 alias grep="${aliases[grep]:-grep} --color=auto"


### PR DESCRIPTION
When aliasing ls to lsd the option -G breaks the sorting behaviour of lsd. Replacing -G by --color=auto resolves this issue.